### PR TITLE
Support RNG operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ defmt = { version = "0.3" }
 log = { version = "0.4.14" }
 
 embedded-hal-async = { version = "=0.2.0-alpha.1"}
+
+
+[features]
+rng = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,4 +340,25 @@ where
             }
         }
     }
+
+    #[cfg(feature = "rng")]
+    /// If supported, generate a 32 bit random value.
+    ///
+    /// Warning: prepare_for_xxx() MUST be called after this operation to set modulation and packet parameters (for example: xxx = tx, rx, cad).
+    /// Do not set modulation and packet parameters, do a random number generation, then initiate Tx, Rx, or CAD.
+    pub async fn get_random_number(&mut self) -> Result<u32, RadioError> {
+        self.rx_continuous = false;
+        self.radio_kind.ensure_ready(self.radio_mode).await?;
+        if self.radio_mode != RadioMode::Standby {
+            self.radio_kind.set_standby().await?;
+            self.radio_mode = RadioMode::Standby;
+        }
+
+        let random_number = self.radio_kind.get_random_number().await?;
+
+        self.radio_kind.set_standby().await?;
+        self.radio_mode = RadioMode::Standby;
+
+        Ok(random_number)
+    }
 }

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -38,6 +38,7 @@ pub enum RadioError {
     DutyCycleUnsupported,
     DutyCycleRxContinuousUnsupported,
     CADUnexpected,
+    RngUnsupported,
 }
 
 /// Status for a received packet

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -98,6 +98,9 @@ pub trait RadioKind {
         mdltn_params: &ModulationParams,
         rx_boosted_if_supported: bool,
     ) -> Result<(), RadioError>;
+    #[cfg(feature = "rng")]
+    /// If supported, generate a 32 bit random value
+    async fn get_random_number(&mut self) -> Result<u32, RadioError>;
     /// Set the LoRa chip to provide notification of specific events based on radio state
     async fn set_irq_params(&mut self, radio_mode: Option<RadioMode>) -> Result<(), RadioError>;
     /// Process LoRa chip notifications of events

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -468,6 +468,12 @@ where
             .await
     }
 
+    #[cfg(feature = "rng")]
+    // Generating a 32 bit random value is not currently supported.
+    async fn get_random_number(&mut self) -> Result<u32, RadioError> {
+        Err(RadioError::RngUnsupported)
+    }
+
     // Set the IRQ mask to disable unwanted interrupts, enable interrupts on DIO0 (the IRQ pin), and allow interrupts.
     async fn set_irq_params(&mut self, radio_mode: Option<RadioMode>) -> Result<(), RadioError> {
         match radio_mode {


### PR DESCRIPTION
Based on a rng feature, support generation of a u32 random number if the LoRa board supports it.

The get_random_number function is added to the lora-phy API.  Access to random number generation is only available through this function, in order to control LoRa board mode at the appropriate level.