### PR TITLE
Add board RAK3172

### DIFF
--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -57,6 +57,7 @@ pub enum BoardType {
     HeltecWifiLoraV31262,
     RpPicoWaveshareSx1262,
     Rak4631Sx1262,
+    Rak3172Sx1262,
     Stm32l0Sx1276,
     Stm32wlSx1262,
 }
@@ -80,6 +81,7 @@ impl From<BoardType> for ChipType {
             BoardType::HeltecWifiLoraV31262 => ChipType::Sx1262,
             BoardType::RpPicoWaveshareSx1262 => ChipType::Sx1262,
             BoardType::Rak4631Sx1262 => ChipType::Sx1262,
+            BoardType::Rak3172Sx1262 => ChipType::Sx1262,
             BoardType::Stm32l0Sx1276 => ChipType::Sx1276,
             BoardType::Stm32wlSx1262 => ChipType::Sx1262,
         }


### PR DESCRIPTION
And do not enable TXCO for RAK3172 since it has a XTAL instead of TXCO.

For reference [see](https://forum.rakwireless.com/t/hse32-tcxo-or-xtal/4764).