### PR TITLE
Remove the static trait bound

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -12,8 +12,8 @@ pub(crate) struct SpiInterface<SPI, IV> {
 
 impl<SPI, IV> SpiInterface<SPI, IV>
 where
-    SPI: SpiBus<u8> + 'static,
-    IV: InterfaceVariant + 'static,
+    SPI: SpiBus<u8>,
+    IV: InterfaceVariant,
 {
     pub fn new(spi: SPI, iv: IV) -> Self {
         Self { spi, iv }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub struct LoRa<RK> {
 
 impl<RK> LoRa<RK>
 where
-    RK: RadioKind + 'static,
+    RK: RadioKind,
 {
     /// Build and return a new instance of the LoRa physical layer API to control an initialized LoRa radio
     pub async fn new(
@@ -344,7 +344,7 @@ where
 
 impl<RK> AsyncRng for LoRa<RK>
 where
-    RK: RngRadio + 'static,
+    RK: RngRadio,
 {
     async fn get_random_number(&mut self) -> Result<u32, RadioError> {
         self.rx_continuous = false;

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -98,8 +98,8 @@ pub struct SX1261_2<SPI, IV> {
 
 impl<SPI, IV> SX1261_2<SPI, IV>
 where
-    SPI: SpiBus<u8> + 'static,
-    IV: InterfaceVariant + 'static,
+    SPI: SpiBus<u8>,
+    IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
     pub fn new(board_type: BoardType, spi: SPI, mut iv: IV) -> Self {
@@ -213,8 +213,8 @@ where
 
 impl<SPI, IV> RadioKind for SX1261_2<SPI, IV>
 where
-    SPI: SpiBus<u8> + 'static,
-    IV: InterfaceVariant + 'static,
+    SPI: SpiBus<u8>,
+    IV: InterfaceVariant,
 {
     fn get_board_type(&self) -> BoardType {
         self.board_type
@@ -929,8 +929,8 @@ where
 
 impl<SPI, IV> crate::RngRadio for SX1261_2<SPI, IV>
 where
-    SPI: SpiBus<u8> + 'static,
-    IV: InterfaceVariant + 'static,
+    SPI: SpiBus<u8>,
+    IV: InterfaceVariant,
 {
     /// Generate a 32 bit random value based on the RSSI readings, after disabling all interrupts.
     /// The random numbers produced by the generator do not have a uniform or Gaussian distribution.

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -85,8 +85,8 @@ pub struct SX1276_7_8_9<SPI, IV> {
 
 impl<SPI, IV> SX1276_7_8_9<SPI, IV>
 where
-    SPI: SpiBus<u8> + 'static,
-    IV: InterfaceVariant + 'static,
+    SPI: SpiBus<u8>,
+    IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
     pub fn new(board_type: BoardType, spi: SPI, mut iv: IV) -> Self {
@@ -127,8 +127,8 @@ where
 
 impl<SPI, IV> RadioKind for SX1276_7_8_9<SPI, IV>
 where
-    SPI: SpiBus<u8> + 'static,
-    IV: InterfaceVariant + 'static,
+    SPI: SpiBus<u8>,
+    IV: InterfaceVariant,
 {
     fn get_board_type(&self) -> BoardType {
         self.board_type


### PR DESCRIPTION
The static trait bounds appear to be unnecessary and are creating issues for the LoRaWAN 1.0.4 implementation.  In all cases, the object in question is moved under the control of lora-phy.

This update does not appear to affect the RNG implementation; however, the appropriate review is requested to double-check this.

