### PR TITLE
change init to be consistent with set_lora_modem() doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,8 @@ where
         self.radio_kind.reset(delay).await?;
         self.radio_kind.ensure_ready(self.radio_mode).await?;
         self.radio_kind.init_rf_switch().await?;
-        self.radio_kind.set_standby().await?;
-        self.radio_mode = RadioMode::Standby;
+        self.radio_kind.set_sleep(delay).await?;
+        self.radio_mode = RadioMode::Sleep;
         self.rx_continuous = false;
         self.radio_kind.set_lora_modem(enable_public_network).await?;
         self.radio_kind.set_oscillator().await?;

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -164,6 +164,7 @@ where
 
     /// The sx127x LoRa mode is set when setting a mode while in sleep mode.
     async fn set_lora_modem(&mut self, enable_public_network: bool) -> Result<(), RadioError> {
+        self.ensure_ready(RadioMode::Sleep).await?;
         if enable_public_network {
             self.write_register(Register::RegSyncWord, LORA_MAC_PUBLIC_SYNCWORD, false)
                 .await


### PR DESCRIPTION
I've been trying to get the Adafruit LoRa Radio RFM95W to work for a while, and found this bit to be inconsistent with the documentation in the sx1276_7_8_9, and was what prevented the radio from working