### PR TITLE
Updates for version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ description = "A LoRa physical layer implementation enabling utilization of a ra
 [dependencies]
 defmt = { version = "0.3" }
 log = { version = "0.4.14" }
+num-traits = { version = "0.2.14", default-features = false }
 
 embedded-hal-async = { version = "=0.2.0-alpha.1"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,18 +65,8 @@ where
         coding_rate: CodingRate,
         frequency_in_hz: u32,
     ) -> Result<ModulationParams, RadioError> {
-        match self.radio_kind.get_board_type().into() {
-            ChipType::Sx1261 | ChipType::Sx1262 | ChipType::CustomSx1261_2 => {
-                ModulationParams::new_for_sx1261_2(spreading_factor, bandwidth, coding_rate, frequency_in_hz)
-            }
-            ChipType::Sx1276
-            | ChipType::Sx1277
-            | ChipType::Sx1278
-            | ChipType::Sx1279
-            | ChipType::CustomSx1276_7_8_9 => {
-                ModulationParams::new_for_sx1276_7_8_9(spreading_factor, bandwidth, coding_rate, frequency_in_hz)
-            }
-        }
+        self.radio_kind
+            .create_modulation_params(spreading_factor, bandwidth, coding_rate, frequency_in_hz)
     }
 
     /// Create packet parameters for a send operation on a communication channel
@@ -88,28 +78,14 @@ where
         iq_inverted: bool,
         modulation_params: &ModulationParams,
     ) -> Result<PacketParams, RadioError> {
-        match self.radio_kind.get_board_type().into() {
-            ChipType::Sx1261 | ChipType::Sx1262 | ChipType::CustomSx1261_2 => PacketParams::new_for_sx1261_2(
-                preamble_length,
-                implicit_header,
-                0,
-                crc_on,
-                iq_inverted,
-                modulation_params,
-            ),
-            ChipType::Sx1276
-            | ChipType::Sx1277
-            | ChipType::Sx1278
-            | ChipType::Sx1279
-            | ChipType::CustomSx1276_7_8_9 => PacketParams::new_for_sx1276_7_8_9(
-                preamble_length,
-                implicit_header,
-                0,
-                crc_on,
-                iq_inverted,
-                modulation_params,
-            ),
-        }
+        self.radio_kind.create_packet_params(
+            preamble_length,
+            implicit_header,
+            0,
+            crc_on,
+            iq_inverted,
+            modulation_params,
+        )
     }
 
     /// Create packet parameters for a receive operation on a communication channel
@@ -122,28 +98,14 @@ where
         iq_inverted: bool,
         modulation_params: &ModulationParams,
     ) -> Result<PacketParams, RadioError> {
-        match self.radio_kind.get_board_type().into() {
-            ChipType::Sx1261 | ChipType::Sx1262 | ChipType::CustomSx1261_2 => PacketParams::new_for_sx1261_2(
-                preamble_length,
-                implicit_header,
-                max_payload_length,
-                crc_on,
-                iq_inverted,
-                modulation_params,
-            ),
-            ChipType::Sx1276
-            | ChipType::Sx1277
-            | ChipType::Sx1278
-            | ChipType::Sx1279
-            | ChipType::CustomSx1276_7_8_9 => PacketParams::new_for_sx1276_7_8_9(
-                preamble_length,
-                implicit_header,
-                max_payload_length,
-                crc_on,
-                iq_inverted,
-                modulation_params,
-            ),
-        }
+        self.radio_kind.create_packet_params(
+            preamble_length,
+            implicit_header,
+            max_payload_length,
+            crc_on,
+            iq_inverted,
+            modulation_params,
+        )
     }
 
     /// Initialize a Semtech chip as the radio for LoRa physical layer communications

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,12 +166,14 @@ where
         self.radio_kind.update_retention_list().await
     }
 
-    /// Place the LoRa physical layer in low power mode, using warm start if the Semtech chip supports it
-    pub async fn sleep(&mut self) -> Result<(), RadioError> {
+    /// Place the LoRa physical layer in low power mode, specifying cold or warm start (if the Semtech chip supports it)
+    pub async fn sleep(&mut self, warm_start_if_possible: bool) -> Result<(), RadioError> {
         if self.radio_mode != RadioMode::Sleep {
             self.radio_kind.ensure_ready(self.radio_mode).await?;
-            let warm_start_enabled = self.radio_kind.set_sleep(&mut self.delay).await?;
-            if !warm_start_enabled {
+            self.radio_kind
+                .set_sleep(warm_start_if_possible, &mut self.delay)
+                .await?;
+            if !warm_start_if_possible {
                 self.image_calibrated = false;
             }
             self.radio_mode = RadioMode::Sleep;

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -124,6 +124,22 @@ pub enum SpreadingFactor {
     _12,
 }
 
+impl SpreadingFactor {
+    /// Convert to numeric value
+    pub fn value(self) -> u32 {
+        match self {
+            SpreadingFactor::_5 => 5,
+            SpreadingFactor::_6 => 6,
+            SpreadingFactor::_7 => 7,
+            SpreadingFactor::_8 => 8,
+            SpreadingFactor::_9 => 9,
+            SpreadingFactor::_10 => 10,
+            SpreadingFactor::_11 => 11,
+            SpreadingFactor::_12 => 12,
+        }
+    }
+}
+
 /// Valid bandwidths for one or more LoRa chips supported by this crate
 #[derive(Clone, Copy, PartialEq)]
 #[allow(missing_docs)]

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -55,12 +55,11 @@ pub struct PacketStatus {
 /// In addition, custom boards (possibly proprietary) can be supported by using the custom board and chip types and
 /// external implementations of the RadioKind and (in some cases) InterfaceVariant traits.  For instance:
 /// let iv = ExternalInterfaceVariantImpl::new(..params...)
-/// LoRa::new(ExternalRadioKindImpl::new(BoardType::CustomSx1261_2, spi, iv), ...other_params...)
+/// LoRa::new(ExternalRadioKindImpl::new(BoardType::CustomBoard, spi, iv), ...other_params...)
 #[derive(Clone, Copy, PartialEq)]
 #[allow(missing_docs)]
 pub enum BoardType {
-    CustomSx1261_2,
-    CustomSx1276_7_8_9,
+    CustomBoard,
     GenericSx1261, // placeholder for Sx1261-specific features
     HeltecWifiLoraV31262,
     RpPicoWaveshareSx1262,
@@ -74,8 +73,7 @@ pub enum BoardType {
 #[derive(Clone, Copy, PartialEq)]
 #[allow(missing_docs)]
 pub enum ChipType {
-    CustomSx1261_2,
-    CustomSx1276_7_8_9,
+    CustomChip,
     Sx1261,
     Sx1262,
     Sx1276,
@@ -87,8 +85,7 @@ pub enum ChipType {
 impl From<BoardType> for ChipType {
     fn from(board_type: BoardType) -> Self {
         match board_type {
-            BoardType::CustomSx1261_2 => ChipType::CustomSx1261_2,
-            BoardType::CustomSx1276_7_8_9 => ChipType::CustomSx1276_7_8_9,
+            BoardType::CustomBoard => ChipType::CustomChip,
             BoardType::GenericSx1261 => ChipType::Sx1261,
             BoardType::HeltecWifiLoraV31262 => ChipType::Sx1262,
             BoardType::RpPicoWaveshareSx1262 => ChipType::Sx1262,

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -32,6 +32,7 @@ pub enum RadioError {
     CRCErrorOnReceive,
     TransmitTimeout,
     ReceiveTimeout,
+    PollingTimeout,
     TimeoutUnexpected,
     TransmitDoneUnexpected,
     ReceiveDoneUnexpected,

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -82,7 +82,6 @@ pub trait RadioKind {
         rx_continuous: bool,
         rx_boosted_if_supported: bool,
         symbol_timeout: u16,
-        rx_timeout_in_ms: u32,
     ) -> Result<(), RadioError>;
     /// Get an available packet made available as the result of a receive operation
     async fn get_rx_payload(
@@ -106,6 +105,7 @@ pub trait RadioKind {
         radio_mode: RadioMode,
         rx_continuous: bool,
         delay: &mut impl DelayUs,
+        polling_timeout_in_ms: Option<u32>,
         cad_activity_detected: Option<&mut bool>,
     ) -> Result<(), RadioError>;
 }

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -30,6 +30,24 @@ pub trait InterfaceVariant {
 pub trait RadioKind {
     /// Get the specific type of the LoRa board (for example, Stm32wlSx1262)
     fn get_board_type(&self) -> BoardType;
+    /// Create modulation parameters specific to the LoRa chip kind and type
+    fn create_modulation_params(
+        &self,
+        spreading_factor: SpreadingFactor,
+        bandwidth: Bandwidth,
+        coding_rate: CodingRate,
+        frequency_in_hz: u32,
+    ) -> Result<ModulationParams, RadioError>;
+    /// Create packet parameters specific to the LoRa chip kind and type
+    fn create_packet_params(
+        &self,
+        preamble_length: u16,
+        implicit_header: bool,
+        payload_length: u8,
+        crc_on: bool,
+        iq_inverted: bool,
+        modulation_params: &ModulationParams,
+    ) -> Result<PacketParams, RadioError>;
     /// Reset the loRa chip
     async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError>;
     /// Ensure the LoRa chip is in the appropriate state to allow operation requests

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -39,7 +39,7 @@ pub trait RadioKind {
     /// Place the LoRa chip in standby mode
     async fn set_standby(&mut self) -> Result<(), RadioError>;
     /// Place the LoRa chip in power-saving mode
-    async fn set_sleep(&mut self, delay: &mut impl DelayUs) -> Result<bool, RadioError>;
+    async fn set_sleep(&mut self, warm_start_if_possible: bool, delay: &mut impl DelayUs) -> Result<(), RadioError>;
     /// Perform operations to set a multi-protocol chip as a LoRa chip
     async fn set_lora_modem(&mut self, enable_public_network: bool) -> Result<(), RadioError>;
     /// Perform operations to set the LoRa chip oscillator

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -105,6 +105,7 @@ pub trait RadioKind {
         &mut self,
         radio_mode: RadioMode,
         rx_continuous: bool,
+        delay: &mut impl DelayUs,
         cad_activity_detected: Option<&mut bool>,
     ) -> Result<(), RadioError>;
 }

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -829,7 +829,7 @@ where
         let mut iteration_guard: u32 = 0;
         if polling_timeout_in_ms.is_some() {
             iteration_guard = polling_timeout_in_ms.unwrap();
-            iteration_guard /= 10; // poll for interrupts every 10 ms until polling timeout
+            iteration_guard /= 50; // poll for interrupts every 50 ms until polling timeout
         }
         let mut i: u32 = 0;
         loop {

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -841,7 +841,7 @@ where
 
             // Await IRQ events unless event polling is used.
             if polling_timeout_in_ms.is_some() {
-                delay.delay_ms(10).await;
+                delay.delay_ms(50).await;
                 i += 1;
             } else {
                 self.intf.iv.await_irq().await?;

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -92,7 +92,7 @@ where
         }
     }
 
-    // Set the number of symbols the radio will wait to validate a reception
+    // Set the number of symbols the radio will wait to detect a reception
     async fn set_lora_symbol_num_timeout(&mut self, symbol_num: u16) -> Result<(), RadioError> {
         let mut exp = 0u8;
         let mut reg;

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -251,18 +251,18 @@ where
         self.intf.iv.disable_rf_switch().await
     }
 
-    async fn set_sleep(&mut self, delay: &mut impl DelayUs) -> Result<bool, RadioError> {
+    async fn set_sleep(&mut self, warm_start_if_possible: bool, delay: &mut impl DelayUs) -> Result<(), RadioError> {
         self.intf.iv.disable_rf_switch().await?;
         let sleep_params = SleepParams {
             wakeup_rtc: false,
             reset: false,
-            warm_start: true,
+            warm_start: warm_start_if_possible,
         };
         let op_code_and_sleep_params = [OpCode::SetSleep.value(), sleep_params.value()];
         self.intf.write(&[&op_code_and_sleep_params], true).await?;
         delay.delay_ms(2).await;
 
-        Ok(sleep_params.warm_start) // indicate if warm start enabled
+        Ok(())
     }
 
     /// Configure the radio for LoRa and a public/private network.

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -557,7 +557,7 @@ where
 
             // Await IRQ events unless event polling is used.
             if polling_timeout_in_ms.is_some() {
-                delay.delay_ms(10).await;
+                delay.delay_ms(50).await;
                 i += 1;
             } else {
                 self.intf.iv.await_irq().await?;

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -136,7 +136,7 @@ where
 
     async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError> {
         self.intf.iv.reset(delay).await?;
-        self.set_sleep(delay).await?; // ensure sleep mode is entered so that the LoRa mode bit is set
+        self.set_sleep(false, delay).await?; // ensure sleep mode is entered so that the LoRa mode bit is set
         Ok(())
     }
 
@@ -155,11 +155,11 @@ where
         self.intf.iv.disable_rf_switch().await
     }
 
-    async fn set_sleep(&mut self, _delay: &mut impl DelayUs) -> Result<bool, RadioError> {
+    async fn set_sleep(&mut self, _warm_start_if_possible: bool, _delay: &mut impl DelayUs) -> Result<(), RadioError> {
         self.intf.iv.disable_rf_switch().await?;
         self.write_register(Register::RegOpMode, LoRaMode::Sleep.value(), true)
             .await?;
-        Ok(false) // warm start unavailable for sx127x
+        Ok(()) // warm start unavailable for sx127x
     }
 
     /// The sx127x LoRa mode is set when setting a mode while in sleep mode.

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -545,7 +545,7 @@ where
         let mut iteration_guard: u32 = 0;
         if polling_timeout_in_ms.is_some() {
             iteration_guard = polling_timeout_in_ms.unwrap();
-            iteration_guard /= 10; // poll for interrupts every 10 ms until polling timeout
+            iteration_guard /= 50; // poll for interrupts every 50 ms until polling timeout
         }
         let mut i: u32 = 0;
         loop {


### PR DESCRIPTION
API changes are made, requiring a new major version.

Enhancements:
- for receive single packet, poll for interrupts to support LoRa chips that would require more than one DIO pin to support timeout IRQs;
- for receive single packet, depend on symbol timeout to prevent window duration timeouts from voiding reception of a packet that needs additional time to be received.  This is useful for LoRaWAN Rx1/Rx2 windowing;
- improve cold start after sleep processing, to prolong battery life between transmissions;
- provide further flexibility to support custom boards through proprietary RadioKind implementations.

API changes are made to the functions that:
- create a LoRa instance;
- prepare for a receive operation.

The RadioKInd trait also has updates to support the lora-phy API.

The custom board and chip type no longer reference a specific LoRa chip type.  As long as the custom/proprietary RadioKind implementation meets the requirements of the RadioKind trait, the custom/proprietary LoRa board may not even need to be an Sx126x or Sx127x and still benefit from working underneath the lora-phy API as part of a P2P or LoRaWAN solution.