### PR TITLE
make DelayUs trait public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ pub mod sx1261_2;
 /// Specific implementation to support Semtech Sx127x chips
 pub mod sx1276_7_8_9;
 
-use embedded_hal_async::delay::DelayUs;
+pub use embedded_hal_async::delay::DelayUs;
+
 use interface::*;
 use mod_params::*;
 use mod_traits::*;


### PR DESCRIPTION
Making this trait public makes it easier for those importing the crate to reference the same version as this crate.