### PR TITLE
loosen up num-traits and log dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A LoRa physical layer implementation enabling utilization of a ra
 
 [dependencies]
 defmt = { version = "0.3" }
-log = { version = "0.4.14" }
-num-traits = { version = "0.2.14", default-features = false }
+log = { version = "0.4" }
+num-traits = { version = "0.2", default-features = false }
 
 embedded-hal-async = { version = "=0.2.0-alpha.2"}


### PR DESCRIPTION
Both of these crates seem unnecessarily constrained to point-releases. Is there a specific reason or may they be loosened up a bit?