### PR TITLE
bump lora-modulation to no_std compatability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "A LoRa physical layer implementation enabling utilization of a ra
 [dependencies]
 defmt = { version = "0.3" }
 log = { version = "0.4" }
-lora-modulation = { version = "0.1.1" }
+lora-modulation = { version = ">=0.1.2" }
 num-traits = { version = "0.2", default-features = false }
 
 embedded-hal-async = { version = "=0.2.0-alpha.2"}


### PR DESCRIPTION
Sorry for [the no_std misfire](https://github.com/embassy-rs/lora-phy/pull/26#issuecomment-1715892151) @ceekdee. I think this should do it though.