### PR TITLE
improve SX12xx/SPI read performance

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -23,14 +23,11 @@ where
     pub async fn write(&mut self, write_buffers: &[&[u8]], is_sleep_command: bool) -> Result<(), RadioError> {
         self.iv.set_nss_low().await?;
         for buffer in write_buffers {
-            let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
-            if write_result != Ok(()) {
+            let write_err = self.spi.write(buffer).await.is_err();
+            let flush_err = self.spi.flush().await.is_err();
+            if write_err || flush_err {
                 let _err = self.iv.set_nss_high().await;
-                write_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
+                return Err(SPI);
             }
         }
         self.iv.set_nss_high().await?;
@@ -55,46 +52,20 @@ where
     }
 
     // Request a read, filling the provided buffer.
-    pub async fn read(
-        &mut self,
-        write_buffers: &[&[u8]],
-        read_buffer: &mut [u8],
-        read_length: Option<u8>,
-    ) -> Result<(), RadioError> {
-        let mut input = [0u8];
-
+    pub async fn read(&mut self, write_buffers: &[&[u8]], read_buffer: &mut [u8]) -> Result<(), RadioError> {
         self.iv.set_nss_low().await?;
         for buffer in write_buffers {
-            let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
-            if write_result != Ok(()) {
+            let write_err = self.spi.write(buffer).await.is_err();
+            let flush_err = self.spi.flush().await.is_err();
+            if write_err || flush_err {
                 let _err = self.iv.set_nss_high().await;
-                write_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
+                return Err(SPI);
             }
         }
 
-        let number_to_read = match read_length {
-            Some(len) => len as usize,
-            None => read_buffer.len(),
-        };
-
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..number_to_read {
-            let transfer_result = self.spi.transfer(&mut input, &[0x00]).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
-            if transfer_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                transfer_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
-            }
-            read_buffer[i] = input[0];
-        }
-        self.iv.set_nss_high().await?;
+        let read_result = self.spi.read(read_buffer).await.map_err(|_| RadioError::SPI);
+        self.iv.set_nss_high();
+        read_result?;
 
         self.iv.wait_on_busy().await?;
 
@@ -109,78 +80,8 @@ where
             ),
             _ => trace!("write: too many buffers"),
         }
-        trace!("read {}: 0x{:x}", number_to_read, read_buffer);
+        trace!("read {}: 0x{:x}", read_buffer.len(), read_buffer);
 
         Ok(())
-    }
-
-    // Request a read with status, filling the provided buffer and returning the status.
-    pub async fn read_with_status(
-        &mut self,
-        write_buffers: &[&[u8]],
-        read_buffer: &mut [u8],
-    ) -> Result<u8, RadioError> {
-        let mut status = [0u8];
-        let mut input = [0u8];
-
-        self.iv.set_nss_low().await?;
-        for buffer in write_buffers {
-            let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
-            if write_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                write_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
-            }
-        }
-
-        let transfer_result = self.spi.transfer(&mut status, &[0x00]).await.map_err(|_| SPI);
-        let flush_result = self.spi.flush().await.map_err(|_| SPI);
-        if transfer_result != Ok(()) {
-            let _err = self.iv.set_nss_high().await;
-            transfer_result?;
-        } else if flush_result != Ok(()) {
-            let _err = self.iv.set_nss_high().await;
-            flush_result?;
-        }
-
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..read_buffer.len() {
-            let transfer_result = self.spi.transfer(&mut input, &[0x00]).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
-            if transfer_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                transfer_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
-            }
-            read_buffer[i] = input[0];
-        }
-        self.iv.set_nss_high().await?;
-
-        self.iv.wait_on_busy().await?;
-
-        match write_buffers.len() {
-            1 => trace!("write: 0x{:x}", write_buffers[0]),
-            2 => trace!("write: 0x{:x} 0x{:x}", write_buffers[0], write_buffers[1]),
-            3 => trace!(
-                "write: 0x{:x} 0x{:x} 0x{:x}",
-                write_buffers[0],
-                write_buffers[1],
-                write_buffers[2]
-            ),
-            _ => trace!("write: too many buffers"),
-        }
-        trace!(
-            "read {} status 0x{:x}: 0x{:x}",
-            read_buffer.len(),
-            status[0],
-            read_buffer
-        );
-
-        Ok(status[0])
     }
 }

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -50,7 +50,7 @@ where
     async fn read_register(&mut self, register: Register) -> Result<u8, RadioError> {
         let write_buffer = [register.read_addr()];
         let mut read_buffer = [0x00u8];
-        self.intf.read(&[&write_buffer], &mut read_buffer, None).await?;
+        self.intf.read(&[&write_buffer], &mut read_buffer).await?;
         Ok(read_buffer[0])
     }
 


### PR DESCRIPTION
Main point of PR is to read _all_ bytes from SX12xx chip with a single SPI transfer. This instead of reading one byte at a time.
This since reading all bytes with one operation is much more performant, especially when reading longer packets and when DMA is used.

While at this some other small things caught my eye. Like repeating some register operations a lot, so did some cleaning there too.