### PR TITLE
Add support for Continuous Wave operation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,9 +396,16 @@ where
         self.radio_kind
             .set_tx_power_and_ramp_time(output_power, Some(mdltn_params), tx_boosted_if_possible, true)
             .await?;
+
+        self.rx_continuous = false;
+        self.radio_kind.ensure_ready(self.radio_mode).await?;
+        if self.radio_mode != RadioMode::Standby {
+            self.radio_kind.set_standby().await?;
+            self.radio_mode = RadioMode::Standby;
+        }
         self.radio_kind.set_channel(mdltn_params.frequency_in_hz).await?;
-        // self.radio_mode = RadioMode::Transmit;
-        // self.radio_kind.set_irq_params(Some(self.radio_mode)).await?;
+        self.radio_mode = RadioMode::Transmit;
+        self.radio_kind.set_irq_params(Some(self.radio_mode)).await?;
         self.radio_kind.set_tx_continuous_wave_mode().await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,15 @@ where
             }
         }
     }
+
+    /// Place radio in continuous wave mode, generally for regulatory testing
+    ///
+    /// SemTech app note AN1200.26 “Semtech LoRa FCC 15.247 Guidance” covers usage.
+    ///
+    /// Presumes that init() and prepare_for_tx() are called before this function
+    pub async fn continuous_wave(&mut self) -> Result<(), RadioError> {
+        self.radio_kind.set_tx_continuous_wave_mode().await
+    }
 }
 
 impl<RK, DLY> AsyncRng for LoRa<RK, DLY>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,7 @@ where
     ///
     /// SemTech app note AN1200.26 “Semtech LoRa FCC 15.247 Guidance” covers usage.
     ///
-    /// Presumes that init() and prepare_for_tx() are called before this function
+    /// Presumes that init() is called before this function
     pub async fn continuous_wave(
         &mut self,
         mdltn_params: &ModulationParams,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,6 +392,10 @@ where
             self.radio_kind.calibrate_image(mdltn_params.frequency_in_hz).await?;
             self.calibrate_image = false;
         }
+        let tx_pkt_params = self
+            .radio_kind
+            .create_packet_params(0, false, 16, false, false, mdltn_params)?;
+        self.radio_kind.set_packet_params(&tx_pkt_params).await?;
         self.radio_kind.set_modulation_params(mdltn_params).await?;
         self.radio_kind
             .set_tx_power_and_ramp_time(output_power, Some(mdltn_params), tx_boosted_if_possible, true)

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -126,6 +126,8 @@ pub trait RadioKind {
         polling_timeout_in_ms: Option<u32>,
         cad_activity_detected: Option<&mut bool>,
     ) -> Result<(), RadioError>;
+    /// Set the LoRa chip into the TxContinuousWave mode
+    async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError>;
 }
 
 /// Internal trait for specifying that a [`RadioKind`] object has RNG capability.

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -947,6 +947,11 @@ where
             // if an interrupt occurred for other than an error or operation completion, loop to wait again
         }
     }
+
+    async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError> {
+        let op_code = [OpCode::SetTxContinuousWave.value()];
+        self.intf.write(&[&op_code], false).await
+    }
 }
 
 impl<SPI, IV> crate::RngRadio for SX1261_2<SPI, IV>

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -949,6 +949,8 @@ where
     }
 
     async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError> {
+        self.intf.iv.enable_rf_switch_tx().await?;
+
         let op_code = [OpCode::SetTxContinuousWave.value()];
         self.intf.write(&[&op_code], false).await
     }

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -608,6 +608,7 @@ where
     }
     /// Set the LoRa chip into the TxContinuousWave mode
     async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError> {
+        self.intf.iv.enable_rf_switch_rx().await?;
         let pa_config = self.read_register(Register::RegPaConfig).await?;
         let new_pa_config = pa_config | 0b1000_0000;
         self.write_register(Register::RegPaConfig, new_pa_config, false).await?;

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -606,4 +606,15 @@ where
             // if an interrupt occurred for other than an error or operation completion, loop to wait again
         }
     }
+    /// Set the LoRa chip into the TxContinuousWave mode
+    async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError> {
+        let pa_config = self.read_register(Register::RegPaConfig).await?;
+        let new_pa_config = pa_config | 0b1000_0000;
+        self.write_register(Register::RegPaConfig, new_pa_config, false).await?;
+        self.write_register(Register::RegOpMode, 0b1100_0011, false).await?;
+        let modem_config = self.read_register(Register::RegModemConfig2).await?;
+        let new_modem_config = modem_config | 0b0000_1000;
+        self.write_register(Register::RegModemConfig2, new_modem_config, false)
+            .await
+    }
 }


### PR DESCRIPTION
This code exposes the Continuous Wave command, which is used for emissions testing a LoRa device.
This code has been tested on a Nucleo64-STM32WL (using the SX1261x interface). The SX127x side is implemented based on documentation. I have no hardware available to verify the SX127x implementation.