### PR TITLE
Add support for sx1272 chip to existing sx1276_7_8_9 driver

### DIFF
--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -22,6 +22,8 @@ const FREQUENCY_SYNTHESIZER_STEP: f64 = 61.03515625; // FXOSC (32 MHz) * 1000000
 /// Supported SX127x chip variants
 #[derive(Clone, Copy)]
 pub enum Sx127xVariant {
+    /// Semtech SX1272
+    Sx1272,
     /// Semtech SX1276
     // TODO: should we add variants for 77, 78 and 79 as well?)
     Sx1276,

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -38,7 +38,7 @@ pub struct Config {
 /// Base for the RadioKind implementation for the LoRa chip kind and board type
 pub struct SX1276_7_8_9<SPI, IV> {
     intf: SpiInterface<SPI, IV>,
-    _config: Config,
+    config: Config,
 }
 
 impl<SPI, IV> SX1276_7_8_9<SPI, IV>
@@ -47,9 +47,9 @@ where
     IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
-    pub fn new(spi: SPI, iv: IV, _config: Config) -> Self {
+    pub fn new(spi: SPI, iv: IV, config: Config) -> Self {
         let intf = SpiInterface::new(spi, iv);
-        Self { intf, _config }
+        Self { intf, config }
     }
 
     // Utility functions
@@ -104,8 +104,8 @@ where
     ) -> Result<ModulationParams, RadioError> {
         // Parameter validation
         spreading_factor_value(spreading_factor)?;
-        bandwidth_value(bandwidth)?;
         coding_rate_value(coding_rate)?;
+        self.config.chip.bandwidth_value(bandwidth)?;
         if ((bandwidth == Bandwidth::_250KHz) || (bandwidth == Bandwidth::_500KHz)) && (frequency_in_hz < 400_000_000) {
             return Err(RadioError::InvalidBandwidthForFrequency);
         }
@@ -279,7 +279,7 @@ where
 
     async fn set_modulation_params(&mut self, mdltn_params: &ModulationParams) -> Result<(), RadioError> {
         let spreading_factor_val = spreading_factor_value(mdltn_params.spreading_factor)?;
-        let bandwidth_val = bandwidth_value(mdltn_params.bandwidth)?;
+        let bandwidth_val = self.config.chip.bandwidth_value(mdltn_params.bandwidth)?;
         let coding_rate_denominator_val = coding_rate_denominator_value(mdltn_params.coding_rate)?;
         debug!(
             "sf = {}, bw = {}, cr_denom = {}",

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -741,14 +741,20 @@ where
     }
     /// Set the LoRa chip into the TxContinuousWave mode
     async fn set_tx_continuous_wave_mode(&mut self) -> Result<(), RadioError> {
-        self.intf.iv.enable_rf_switch_rx().await?;
-        let pa_config = self.read_register(Register::RegPaConfig).await?;
-        let new_pa_config = pa_config | 0b1000_0000;
-        self.write_register(Register::RegPaConfig, new_pa_config, false).await?;
-        self.write_register(Register::RegOpMode, 0b1100_0011, false).await?;
-        let modem_config = self.read_register(Register::RegModemConfig2).await?;
-        let new_modem_config = modem_config | 0b0000_1000;
-        self.write_register(Register::RegModemConfig2, new_modem_config, false)
-            .await
+        match self.config.chip {
+            Sx127xVariant::Sx1272 => todo!(),
+            Sx127xVariant::Sx1276 => {
+                self.intf.iv.enable_rf_switch_rx().await?;
+                let pa_config = self.read_register(Register::RegPaConfig).await?;
+                let new_pa_config = pa_config | 0b1000_0000;
+                self.write_register(Register::RegPaConfig, new_pa_config, false).await?;
+                self.write_register(Register::RegOpMode, 0b1100_0011, false).await?;
+                let modem_config = self.read_register(Register::RegModemConfig2).await?;
+                let new_modem_config = modem_config | 0b0000_1000;
+                self.write_register(Register::RegModemConfig2, new_modem_config, false)
+                    .await?;
+            }
+        }
+        Ok(())
     }
 }

--- a/src/sx1276_7_8_9/radio_kind_params.rs
+++ b/src/sx1276_7_8_9/radio_kind_params.rs
@@ -102,7 +102,8 @@ pub enum Register {
     RegDioMapping1 = 0x40,
     RegVersion = 0x42,
     RegTcxo = 0x4b,
-    RegPaDac = 0x4d,
+    RegPaDacSX1272 = 0x5a,
+    RegPaDacSX1276 = 0x4d,
 }
 
 impl Register {
@@ -161,6 +162,7 @@ impl LnaGain {
     }
 }
 
+/// PA DAC configuration - sx1276+
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
 pub enum PaDac {
@@ -174,6 +176,7 @@ impl PaDac {
     }
 }
 
+/// PA configuration - sx1276+
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
 pub enum PaConfig {

--- a/src/sx1276_7_8_9/radio_kind_params.rs
+++ b/src/sx1276_7_8_9/radio_kind_params.rs
@@ -1,4 +1,5 @@
 use crate::mod_params::*;
+use crate::sx1276_7_8_9::Sx127xVariant;
 
 /// Internal sx127x LoRa modes (signified by most significant bit flag)
 #[derive(Clone, Copy)]
@@ -239,8 +240,27 @@ pub fn spreading_factor_value(spreading_factor: SpreadingFactor) -> Result<u8, R
     }
 }
 
-pub fn bandwidth_value(bandwidth: Bandwidth) -> Result<u8, RadioError> {
-    match bandwidth {
+impl Sx127xVariant {
+    /// Convert bandwidth to chip-specific register value
+    pub fn bandwidth_value(self, bw: Bandwidth) -> Result<u8, RadioError> {
+        match self {
+            Sx127xVariant::Sx1272 => bw_sx1272(bw),
+            Sx127xVariant::Sx1276 => bw_sx1276(bw),
+        }
+    }
+}
+
+fn bw_sx1272(bw: Bandwidth) -> Result<u8, RadioError> {
+    match bw {
+        Bandwidth::_125KHz => Ok(0x00),
+        Bandwidth::_250KHz => Ok(0x01),
+        Bandwidth::_500KHz => Ok(0x02),
+        _ => Err(RadioError::UnavailableBandwidth),
+    }
+}
+
+fn bw_sx1276(bw: Bandwidth) -> Result<u8, RadioError> {
+    match bw {
         Bandwidth::_7KHz => Ok(0x00),
         Bandwidth::_10KHz => Ok(0x01),
         Bandwidth::_15KHz => Ok(0x02),

--- a/src/sx1276_7_8_9/radio_kind_params.rs
+++ b/src/sx1276_7_8_9/radio_kind_params.rs
@@ -101,9 +101,10 @@ pub enum Register {
     RegInvertiq2 = 0x3b,
     RegDioMapping1 = 0x40,
     RegVersion = 0x42,
-    RegTcxo = 0x4b,
     RegPaDacSX1272 = 0x5a,
     RegPaDacSX1276 = 0x4d,
+    RegTcxoSX1276 = 0x4b,
+    RegTcxoSX1272 = 0x58,
 }
 
 impl Register {


### PR DESCRIPTION
This is initial RFC PR for sx1272 support added into existing sx1276+ driver.

It's now good enough to rx/tx P2P packets, but there's some work still left to deal with preamble support (will be handled in separate PR).

While implementing support, I have ran into following issues where each of these probably warrants its own design discussion:
1. ~Tcxo support - currently it is assumed to be always enabled, but instead it should be handled via board configuration (see the final commit)~.
2. Tx output routing is board specific and on some chips depends on selected frequency as well (This is currently breaking LoRa for me as rust-lorawan currently calls phy with boost disabled (`lora.prepare_for_tx(..)`) 
3. ~Dio configuration - should allow more pins.. ?~ - Handled via interface.
4. ~Type leakage.. (ie I had to add `BoardType::GenericSx1272` into `sx1261_2` driver)~