### PR TITLE
SpiBus -> SpiDevice

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,5 +1,5 @@
 use defmt::trace;
-use embedded_hal_async::spi::SpiDevice;
+use embedded_hal_async::spi::{Operation, SpiDevice};
 
 use crate::mod_params::RadioError;
 use crate::mod_params::RadioError::*;
@@ -19,125 +19,70 @@ where
         Self { spi, iv }
     }
 
-    // Write one or more buffers to the radio.
-    pub async fn write(&mut self, write_buffers: &[&[u8]], is_sleep_command: bool) -> Result<(), RadioError> {
-        for buffer in write_buffers {
-            let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            if write_result != Ok(()) {
-                write_result?;
-            }
-        }
+    // Write a buffer to the radio.
+    pub async fn write(&mut self, write_buffer: &[u8], is_sleep_command: bool) -> Result<(), RadioError> {
+        self.spi.write(&write_buffer).await.map_err(|_| SPI)?;
 
         if !is_sleep_command {
             self.iv.wait_on_busy().await?;
         }
 
-        match write_buffers.len() {
-            1 => trace!("write: 0x{:x}", write_buffers[0]),
-            2 => trace!("write: 0x{:x} 0x{:x}", write_buffers[0], write_buffers[1]),
-            3 => trace!(
-                "write: 0x{:x} 0x{:x} 0x{:x}",
-                write_buffers[0],
-                write_buffers[1],
-                write_buffers[2]
-            ),
-            _ => trace!("write: too many buffers"),
+        trace!("write: 0x{:x}", write_buffer);
+
+        Ok(())
+    }
+
+    // Write
+    pub async fn write_with_payload(
+        &mut self,
+        write_buffer: &[u8],
+        payload: &[u8],
+        is_sleep_command: bool,
+    ) -> Result<(), RadioError> {
+        let mut ops = [Operation::Write(write_buffer), Operation::Write(payload)];
+        self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
+
+        if !is_sleep_command {
+            self.iv.wait_on_busy().await?;
         }
+
+        trace!("write: 0x{:x}", write_buffer);
 
         Ok(())
     }
 
     // Request a read, filling the provided buffer.
-    pub async fn read(
-        &mut self,
-        write_buffers: &[&[u8]],
-        read_buffer: &mut [u8],
-        read_length: Option<u8>,
-    ) -> Result<(), RadioError> {
-        let mut input = [0u8];
+    pub async fn read(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<(), RadioError> {
+        {
+            let mut ops = [Operation::Write(write_buffer), Operation::Read(read_buffer)];
 
-        for buffer in write_buffers {
-            let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            if write_result != Ok(()) {
-                write_result?;
-            }
-        }
-
-        let number_to_read = match read_length {
-            Some(len) => len as usize,
-            None => read_buffer.len(),
-        };
-
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..number_to_read {
-            let transfer_result = self.spi.transfer(&mut input, &[0x00]).await.map_err(|_| SPI);
-            if transfer_result != Ok(()) {
-                transfer_result?;
-            }
-            read_buffer[i] = input[0];
+            self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
         }
 
         self.iv.wait_on_busy().await?;
 
-        match write_buffers.len() {
-            1 => trace!("write: 0x{:x}", write_buffers[0]),
-            2 => trace!("write: 0x{:x} 0x{:x}", write_buffers[0], write_buffers[1]),
-            3 => trace!(
-                "write: 0x{:x} 0x{:x} 0x{:x}",
-                write_buffers[0],
-                write_buffers[1],
-                write_buffers[2]
-            ),
-            _ => trace!("write: too many buffers"),
-        }
-        trace!("read {}: 0x{:x}", number_to_read, read_buffer);
+        trace!("write: 0x{:x}", write_buffer);
+        trace!("read {}: 0x{:x}", read_buffer.len(), read_buffer);
 
         Ok(())
     }
 
     // Request a read with status, filling the provided buffer and returning the status.
-    pub async fn read_with_status(
-        &mut self,
-        write_buffers: &[&[u8]],
-        read_buffer: &mut [u8],
-    ) -> Result<u8, RadioError> {
+    pub async fn read_with_status(&mut self, write_buffer: &[u8], read_buffer: &mut [u8]) -> Result<u8, RadioError> {
         let mut status = [0u8];
-        let mut input = [0u8];
+        {
+            let mut ops = [
+                Operation::Write(write_buffer),
+                Operation::Read(&mut status),
+                Operation::Read(read_buffer),
+            ];
 
-        for buffer in write_buffers {
-            let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            if write_result != Ok(()) {
-                write_result?;
-            }
-        }
-
-        let transfer_result = self.spi.transfer(&mut status, &[0x00]).await.map_err(|_| SPI);
-        if transfer_result != Ok(()) {
-            transfer_result?;
-        }
-
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..read_buffer.len() {
-            let transfer_result = self.spi.transfer(&mut input, &[0x00]).await.map_err(|_| SPI);
-            if transfer_result != Ok(()) {
-                transfer_result?;
-            }
-            read_buffer[i] = input[0];
+            self.spi.transaction(&mut ops).await.map_err(|_| SPI)?;
         }
 
         self.iv.wait_on_busy().await?;
 
-        match write_buffers.len() {
-            1 => trace!("write: 0x{:x}", write_buffers[0]),
-            2 => trace!("write: 0x{:x} 0x{:x}", write_buffers[0], write_buffers[1]),
-            3 => trace!(
-                "write: 0x{:x} 0x{:x} 0x{:x}",
-                write_buffers[0],
-                write_buffers[1],
-                write_buffers[2]
-            ),
-            _ => trace!("write: too many buffers"),
-        }
+        trace!("write: 0x{:x}", write_buffer);
         trace!(
             "read {} status 0x{:x}: 0x{:x}",
             read_buffer.len(),

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,5 +1,5 @@
 use defmt::trace;
-use embedded_hal_async::spi::SpiBus;
+use embedded_hal_async::spi::SpiDevice;
 
 use crate::mod_params::RadioError;
 use crate::mod_params::RadioError::*;
@@ -12,7 +12,7 @@ pub(crate) struct SpiInterface<SPI, IV> {
 
 impl<SPI, IV> SpiInterface<SPI, IV>
 where
-    SPI: SpiBus<u8>,
+    SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
     pub fn new(spi: SPI, iv: IV) -> Self {
@@ -21,19 +21,12 @@ where
 
     // Write one or more buffers to the radio.
     pub async fn write(&mut self, write_buffers: &[&[u8]], is_sleep_command: bool) -> Result<(), RadioError> {
-        self.iv.set_nss_low().await?;
         for buffer in write_buffers {
             let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
             if write_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
                 write_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
             }
         }
-        self.iv.set_nss_high().await?;
 
         if !is_sleep_command {
             self.iv.wait_on_busy().await?;
@@ -63,16 +56,10 @@ where
     ) -> Result<(), RadioError> {
         let mut input = [0u8];
 
-        self.iv.set_nss_low().await?;
         for buffer in write_buffers {
             let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
             if write_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
                 write_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
             }
         }
 
@@ -84,17 +71,11 @@ where
         #[allow(clippy::needless_range_loop)]
         for i in 0..number_to_read {
             let transfer_result = self.spi.transfer(&mut input, &[0x00]).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
             if transfer_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
                 transfer_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
             }
             read_buffer[i] = input[0];
         }
-        self.iv.set_nss_high().await?;
 
         self.iv.wait_on_busy().await?;
 
@@ -123,43 +104,26 @@ where
         let mut status = [0u8];
         let mut input = [0u8];
 
-        self.iv.set_nss_low().await?;
         for buffer in write_buffers {
             let write_result = self.spi.write(buffer).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
             if write_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
                 write_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
             }
         }
 
         let transfer_result = self.spi.transfer(&mut status, &[0x00]).await.map_err(|_| SPI);
-        let flush_result = self.spi.flush().await.map_err(|_| SPI);
         if transfer_result != Ok(()) {
-            let _err = self.iv.set_nss_high().await;
             transfer_result?;
-        } else if flush_result != Ok(()) {
-            let _err = self.iv.set_nss_high().await;
-            flush_result?;
         }
 
         #[allow(clippy::needless_range_loop)]
         for i in 0..read_buffer.len() {
             let transfer_result = self.spi.transfer(&mut input, &[0x00]).await.map_err(|_| SPI);
-            let flush_result = self.spi.flush().await.map_err(|_| SPI);
             if transfer_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
                 transfer_result?;
-            } else if flush_result != Ok(()) {
-                let _err = self.iv.set_nss_high().await;
-                flush_result?;
             }
             read_buffer[i] = input[0];
         }
-        self.iv.set_nss_high().await?;
 
         self.iv.wait_on_busy().await?;
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,8 +1,7 @@
 use defmt::trace;
 use embedded_hal_async::spi::{Operation, SpiDevice};
 
-use crate::mod_params::RadioError;
-use crate::mod_params::RadioError::*;
+use crate::mod_params::RadioError::{self, SPI};
 use crate::mod_traits::InterfaceVariant;
 
 pub(crate) struct SpiInterface<SPI, IV> {
@@ -21,7 +20,7 @@ where
 
     // Write a buffer to the radio.
     pub async fn write(&mut self, write_buffer: &[u8], is_sleep_command: bool) -> Result<(), RadioError> {
-        self.spi.write(&write_buffer).await.map_err(|_| SPI)?;
+        self.spi.write(write_buffer).await.map_err(|_| SPI)?;
 
         if !is_sleep_command {
             self.iv.wait_on_busy().await?;

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -8,7 +8,6 @@ pub use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 #[allow(dead_code, missing_docs)]
 pub enum RadioError {
     SPI,
-    NSS,
     Reset,
     RfSwitchRx,
     RfSwitchTx,

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -7,10 +7,6 @@ use crate::mod_params::*;
 pub trait InterfaceVariant {
     /// Set the LoRa board type
     fn set_board_type(&mut self, board_type: BoardType);
-    /// Select the LoRa chip for an operation
-    async fn set_nss_low(&mut self) -> Result<(), RadioError>;
-    /// De-select the LoRa chip after an operation
-    async fn set_nss_high(&mut self) -> Result<(), RadioError>;
     /// Reset the LoRa chip
     async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError>;
     /// Wait for the LoRa chip to become available for an operation

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -39,7 +39,7 @@ pub struct SX1261_2<SPI, IV> {
 
 impl<SPI, IV> SX1261_2<SPI, IV>
 where
-    SPI: SpiBus<u8>,
+    SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
@@ -154,7 +154,7 @@ where
 
 impl<SPI, IV> RadioKind for SX1261_2<SPI, IV>
 where
-    SPI: SpiBus<u8>,
+    SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
     fn get_board_type(&self) -> BoardType {
@@ -965,7 +965,7 @@ where
 
 impl<SPI, IV> crate::RngRadio for SX1261_2<SPI, IV>
 where
-    SPI: SpiBus<u8>,
+    SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
     /// Generate a 32 bit random value based on the RSSI readings, after disabling all interrupts.

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -45,13 +45,13 @@ where
         is_sleep_command: bool,
     ) -> Result<(), RadioError> {
         let write_buffer = [register.write_addr(), value];
-        self.intf.write(&[&write_buffer], is_sleep_command).await
+        self.intf.write(&write_buffer, is_sleep_command).await
     }
 
     async fn read_register(&mut self, register: Register) -> Result<u8, RadioError> {
         let write_buffer = [register.read_addr()];
         let mut read_buffer = [0x00u8];
-        self.intf.read(&[&write_buffer], &mut read_buffer, None).await?;
+        self.intf.read(&write_buffer, &mut read_buffer).await?;
         Ok(read_buffer[0])
     }
 

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -27,7 +27,7 @@ pub struct SX1276_7_8_9<SPI, IV> {
 
 impl<SPI, IV> SX1276_7_8_9<SPI, IV>
 where
-    SPI: SpiBus<u8>,
+    SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
@@ -77,7 +77,7 @@ where
 
 impl<SPI, IV> RadioKind for SX1276_7_8_9<SPI, IV>
 where
-    SPI: SpiBus<u8>,
+    SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
     fn get_board_type(&self) -> BoardType {


### PR DESCRIPTION
Should close #31. Will also conflict with #29, but because the change from SpiBus to SpiDevice also required switching to spi transactions, it should have a similar effect on perf as #29.

I've tested on my hardware (custom rp240 board and sx1262 boards), and it works here. I don't have an sx1261 or sx127x to test against, though I doubt this will cause issues for those parts. I'm more concerned about the stm32wl, as I don't know how it's weird internal spi interface works, and as such have marked this a draft.

This is also a breaking change that would require a major version bump.