### PR TITLE
Define GenerixSx1272 and GenericSx1276 board types

### DIFF
--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -63,6 +63,8 @@ pub struct PacketStatus {
 pub enum BoardType {
     CustomBoard,
     GenericSx1261, // placeholder for Sx1261-specific features
+    GenericSx1272,
+    GenericSx1276,
     HeltecWifiLoraV31262,
     RpPicoWaveshareSx1262,
     Rak4631Sx1262,
@@ -78,6 +80,7 @@ pub enum ChipType {
     CustomChip,
     Sx1261,
     Sx1262,
+    Sx1272,
     Sx1276,
     Sx1277,
     Sx1278,
@@ -89,6 +92,8 @@ impl From<BoardType> for ChipType {
         match board_type {
             BoardType::CustomBoard => ChipType::CustomChip,
             BoardType::GenericSx1261 => ChipType::Sx1261,
+            BoardType::GenericSx1272 => ChipType::Sx1272,
+            BoardType::GenericSx1276 => ChipType::Sx1276,
             BoardType::HeltecWifiLoraV31262 => ChipType::Sx1262,
             BoardType::RpPicoWaveshareSx1262 => ChipType::Sx1262,
             BoardType::Rak4631Sx1262 => ChipType::Sx1262,

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -291,7 +291,7 @@ where
     async fn set_oscillator(&mut self) -> Result<(), RadioError> {
         // voltage used to control the TCXO on/off from DIO3
         let voltage = match self.board_type {
-            BoardType::CustomBoard | BoardType::Stm32l0Sx1276 => {
+            BoardType::CustomBoard | BoardType::GenericSx1272 | BoardType::GenericSx1276 | BoardType::Stm32l0Sx1276 => {
                 return Err(RadioError::BoardTypeUnsupportedForRadioKind);
             }
             BoardType::Rak3172Sx1262 => {


### PR DESCRIPTION
In long run, the BoardType enum should be dropped in favor of a struct-based approach and probably a Sealed implementation for chips as well, but at least add some generic board definitions to allow out-of tree implementations for sx1272 and sx1276-based boards.