### PR TITLE
Drop global BoardType enum in favor of driver-specific configuration struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,7 @@ Example RadioKind implementations and ancillary information:
 
 ## LoRa board-specific support
 
-LoRa boards use LoRa chip features differently.  To suppport these variations within a radio kind implementation, BoardType and ChipType are available:
-
-- <a href="https://github.com/embassy-rs/lora-phy/blob/main/src/mod_params.rs">scroll to BoardType and ChipType</a>.
-
-One can add a LoRa board (the board name includes the chip type in case the board may include a range of chip types) and the ChipType, then modify the radio kind processing to support board-specific features.  The ChipType is used for generic checks, alleviating the need to add a new board type check in places where a generic check will do.  BoardType checks only need to be implemented where the specificity is board-related.  There are examples of each type of check here:
-
-- <a href="https://github.com/embassy-rs/lora-phy/blob/main/src/sx1261_2/mod.rs">search for BoardType and ChipType</a>.
+Board-specific configuration can be handled via the chip driver specific Config struct.
 
 ## Chat
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,11 +61,6 @@ where
         Ok(lora)
     }
 
-    /// Get the board type of the LoRa board
-    pub fn get_board_type(&self) -> BoardType {
-        self.radio_kind.get_board_type()
-    }
-
     /// Create modulation parameters for a communication channel
     pub fn create_modulation_params(
         &mut self,

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -70,34 +70,6 @@ pub enum BoardType {
     Stm32wlSx1262,
 }
 
-/// LoRa chips supported by this crate
-#[derive(Clone, Copy, PartialEq)]
-#[allow(missing_docs)]
-pub enum ChipType {
-    CustomChip,
-    Sx1261,
-    Sx1262,
-    Sx1276,
-    Sx1277,
-    Sx1278,
-    Sx1279,
-}
-
-impl From<BoardType> for ChipType {
-    fn from(board_type: BoardType) -> Self {
-        match board_type {
-            BoardType::CustomBoard => ChipType::CustomChip,
-            BoardType::GenericSx1261 => ChipType::Sx1261,
-            BoardType::HeltecWifiLoraV31262 => ChipType::Sx1262,
-            BoardType::RpPicoWaveshareSx1262 => ChipType::Sx1262,
-            BoardType::Rak4631Sx1262 => ChipType::Sx1262,
-            BoardType::Rak3172Sx1262 => ChipType::Sx1262,
-            BoardType::Stm32l0Sx1276 => ChipType::Sx1276,
-            BoardType::Stm32wlSx1262 => ChipType::Sx1262,
-        }
-    }
-}
-
 /// The state of the radio
 #[derive(Clone, Copy, defmt::Format, PartialEq)]
 #[allow(missing_docs)]

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -52,24 +52,6 @@ pub struct PacketStatus {
     pub snr: i16,
 }
 
-/// LoRa boards supported by this crate.
-/// In addition, custom boards (possibly proprietary) can be supported by using the custom board and chip types and
-/// external implementations of the RadioKind and (in some cases) InterfaceVariant traits.  For instance:
-/// let iv = ExternalInterfaceVariantImpl::new(..params...)
-/// LoRa::new(ExternalRadioKindImpl::new(BoardType::CustomBoard, spi, iv), ...other_params...)
-#[derive(Clone, Copy, PartialEq)]
-#[allow(missing_docs)]
-pub enum BoardType {
-    CustomBoard,
-    GenericSx1261, // placeholder for Sx1261-specific features
-    HeltecWifiLoraV31262,
-    RpPicoWaveshareSx1262,
-    Rak4631Sx1262,
-    Rak3172Sx1262,
-    Stm32l0Sx1276,
-    Stm32wlSx1262,
-}
-
 /// The state of the radio
 #[derive(Clone, Copy, defmt::Format, PartialEq)]
 #[allow(missing_docs)]

--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -5,7 +5,7 @@ pub use lora_modulation::{Bandwidth, CodingRate, SpreadingFactor};
 /// Errors types reported during LoRa physical layer processing
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, defmt::Format, PartialEq)]
-#[allow(dead_code, missing_docs)]
+#[allow(missing_docs)]
 pub enum RadioError {
     SPI,
     Reset,
@@ -41,7 +41,6 @@ pub enum RadioError {
     DutyCycleRxContinuousUnsupported,
     CADUnexpected,
     RngUnsupported,
-    BoardTypeUnsupportedForRadioKind,
 }
 
 /// Status for a received packet

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -5,8 +5,6 @@ use crate::mod_params::*;
 /// Functions implemented for an embedded framework for an MCU/LoRa chip combination
 /// to allow this crate to control the LoRa chip.
 pub trait InterfaceVariant {
-    /// Set the LoRa board type
-    fn set_board_type(&mut self, board_type: BoardType);
     /// Reset the LoRa chip
     async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError>;
     /// Wait for the LoRa chip to become available for an operation
@@ -42,8 +40,6 @@ pub enum IrqState {
 /// Functions implemented for a specific kind of LoRa chip, called internally by the outward facing
 /// LoRa physical layer API
 pub trait RadioKind {
-    /// Get the specific type of the LoRa board (for example, Stm32wlSx1262)
-    fn get_board_type(&self) -> BoardType;
     /// Create modulation parameters specific to the LoRa chip kind and type
     fn create_modulation_params(
         &self,

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -54,7 +54,6 @@ pub struct Config {
 
 /// Base for the RadioKind implementation for the LoRa chip kind and board type
 pub struct SX1261_2<SPI, IV> {
-    board_type: BoardType,
     intf: SpiInterface<SPI, IV>,
     config: Config,
 }
@@ -65,14 +64,9 @@ where
     IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
-    pub fn new(board_type: BoardType, spi: SPI, mut iv: IV, config: Config) -> Self {
-        iv.set_board_type(board_type);
+    pub fn new(spi: SPI, iv: IV, config: Config) -> Self {
         let intf = SpiInterface::new(spi, iv);
-        Self {
-            board_type,
-            intf,
-            config,
-        }
+        Self { intf, config }
     }
 
     // Utility functions
@@ -182,10 +176,6 @@ where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
-    fn get_board_type(&self) -> BoardType {
-        self.board_type
-    }
-
     fn create_modulation_params(
         &self,
         spreading_factor: SpreadingFactor,

--- a/src/sx1261_2/radio_kind_params.rs
+++ b/src/sx1261_2/radio_kind_params.rs
@@ -208,7 +208,6 @@ impl CalibrationParams {
 }
 
 #[derive(Clone, Copy)]
-#[allow(dead_code)]
 pub enum TcxoCtrlVoltage {
     Ctrl1V6 = 0x00,
     Ctrl1V7 = 0x01,

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -19,10 +19,21 @@ const TCXO_FOR_OSCILLATOR: u8 = 0x10u8;
 // Frequency synthesizer step for frequency calculation (Hz)
 const FREQUENCY_SYNTHESIZER_STEP: f64 = 61.03515625; // FXOSC (32 MHz) * 1000000 (Hz/MHz) / 524288 (2^19)
 
+/// Supported SX127x chip variants for further device-specific customizations
+/// Currently SX1276, SX1277, SX1278 and SX1279 are supported
+pub enum Sx127xVariant {}
+
+/// Configuration for SX127x-based boards
+pub struct Config {
+    /// LoRa chip variant on this board
+    pub chip: Sx127xVariant,
+}
+
 /// Base for the RadioKind implementation for the LoRa chip kind and board type
 pub struct SX1276_7_8_9<SPI, IV> {
     board_type: BoardType,
     intf: SpiInterface<SPI, IV>,
+    _config: Config,
 }
 
 impl<SPI, IV> SX1276_7_8_9<SPI, IV>
@@ -31,10 +42,10 @@ where
     IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
-    pub fn new(board_type: BoardType, spi: SPI, mut iv: IV) -> Self {
+    pub fn new(board_type: BoardType, spi: SPI, mut iv: IV, _config: Config) -> Self {
         iv.set_board_type(board_type);
         let intf = SpiInterface::new(spi, iv);
-        Self { board_type, intf }
+        Self { board_type, intf, _config }
     }
 
     // Utility functions

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -31,7 +31,6 @@ pub struct Config {
 
 /// Base for the RadioKind implementation for the LoRa chip kind and board type
 pub struct SX1276_7_8_9<SPI, IV> {
-    board_type: BoardType,
     intf: SpiInterface<SPI, IV>,
     _config: Config,
 }
@@ -42,10 +41,9 @@ where
     IV: InterfaceVariant,
 {
     /// Create an instance of the RadioKind implementation for the LoRa chip kind and board type
-    pub fn new(board_type: BoardType, spi: SPI, mut iv: IV, _config: Config) -> Self {
-        iv.set_board_type(board_type);
+    pub fn new(spi: SPI, iv: IV, _config: Config) -> Self {
         let intf = SpiInterface::new(spi, iv);
-        Self { board_type, intf, _config }
+        Self { intf, _config }
     }
 
     // Utility functions
@@ -91,10 +89,6 @@ where
     SPI: SpiDevice<u8>,
     IV: InterfaceVariant,
 {
-    fn get_board_type(&self) -> BoardType {
-        self.board_type
-    }
-
     fn create_modulation_params(
         &self,
         spreading_factor: SpreadingFactor,


### PR DESCRIPTION
Refactor to get rid of global BoardType and ChipType enum in favor of interface-specific board configuration struct.

NB! Breaks existing APIs:
* Rust LoRaWAN - https://github.com/ivajloip/rust-lorawan/pull/152