### PR TITLE
Clamp tx power between driver-specific values

### DIFF
--- a/src/mod_params.rs
+++ b/src/mod_params.rs
@@ -26,7 +26,6 @@ pub enum RadioError {
     UnavailableCodingRate,
     InvalidBandwidthForFrequency,
     InvalidSF6ExplicitHeaderRequest,
-    InvalidOutputPower,
     InvalidOutputPowerForFrequency,
     HeaderError,
     CRCErrorUnexpected,

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -363,10 +363,10 @@ where
         // TODO: Switch to match so all chip variants are covered
         let chip_type = &self.config.chip;
         if chip_type == &Sx126xVariant::Sx1261 {
-            if !(-17..=15).contains(&output_power) {
-                return Err(RadioError::InvalidOutputPower);
-            }
-            if output_power == 15 {
+            // Clamp power between [-17, 15] dBm
+            let txp = output_power.min(15).max(-17);
+
+            if txp == 15 {
                 if let Some(m_p) = mdltn_params {
                     if m_p.frequency_in_hz < 400_000_000 {
                         return Err(RadioError::InvalidOutputPowerForFrequency);
@@ -374,7 +374,11 @@ where
                 }
             }
 
-            match output_power {
+            // For SX1261:
+            // if f < 400 MHz, paDutyCycle should not be higher than 0x04,
+            // if f > 400 Mhz, paDutyCycle should not be higher than 0x07.
+            // From Table 13-21: PA Operating Modes with Optimal Settings
+            match txp {
                 15 => {
                     self.set_pa_config(0x06, 0x00, 0x01, 0x01).await?;
                     tx_params_power = 14;
@@ -385,11 +389,11 @@ where
                 }
                 10 => {
                     self.set_pa_config(0x01, 0x00, 0x01, 0x01).await?;
-                    tx_params_power = 14;
+                    tx_params_power = 13;
                 }
                 _ => {
                     self.set_pa_config(0x04, 0x00, 0x01, 0x01).await?;
-                    tx_params_power = output_power as u8;
+                    tx_params_power = txp as u8;
                 }
             }
         } else {


### PR DESCRIPTION
Instead of erroring out with `InvalidOutputPower`, clamp support TX power between chip-supported values. Proper region-specific limiting is handled in upper layers (rust-rs) and it's up to user to choose the correct chip for each region.
Upper layers also provide support for adjusting output power related to antenna gain as well.

Related:
* https://github.com/lora-rs/lora-rs/pull/159
* https://github.com/lora-rs/lora-rs/pull/166