### PR TITLE
sx126x: Make DIO2 functionality configurable

### DIFF
--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -53,6 +53,8 @@ pub struct Config {
     pub tcxo_ctrl: Option<TcxoCtrlVoltage>,
     /// Whether board is using optional DCDC in addition to LDO
     pub use_dcdc: bool,
+    /// Whether board is using DIO2 as RF switch (true) or as an IRQ
+    pub use_dio2_as_rfswitch: bool,
 }
 
 /// Base for the RadioKind implementation for the LoRa chip kind and board type
@@ -252,10 +254,11 @@ where
 
     // Use DIO2 to control an RF Switch, depending on the board type.
     async fn init_rf_switch(&mut self) -> Result<(), RadioError> {
-        if self.config.chip != Sx126xVariant::Stm32wl {
-            let op_code_and_indicator = [OpCode::SetRFSwitchMode.value(), true as u8];
-            self.intf.write(&op_code_and_indicator, false).await?;
-        }
+        let reg_data = [
+            OpCode::SetDIO2AsRfSwitchCtrl.value(),
+            self.config.use_dio2_as_rfswitch as u8,
+        ];
+        self.intf.write(&reg_data, false).await?;
         Ok(())
     }
 

--- a/src/sx1261_2/radio_kind_params.rs
+++ b/src/sx1261_2/radio_kind_params.rs
@@ -114,7 +114,7 @@ pub enum OpCode {
     ClrErrors = 0x07,
     SetTCXOMode = 0x97,
     SetTxFallbackMode = 0x93,
-    SetRFSwitchMode = 0x9D,
+    SetDIO2AsRfSwitchCtrl = 0x9d,
     SetStopRxTimerOnPreamble = 0x9F,
     SetLoRaSymbTimeout = 0xA0,
 }


### PR DESCRIPTION
Another board-specific tweak is DIO2 configuration - whether this is used as IRQ or as RF Switch.

This also means that we should rethink how InterfaceVariant should be handled regarding RfSwitch integration...