### PR TITLE
Bump dep, toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Switch SpiInterface to use SpiDevice trait.
 - Implement functionality for continuous wave mode.
 - Support preamble detection allowing LoRaWAN RX1+RX2 reception.
+- Update embedded-hal-async to 1.0.0-rc.3
 
 ## [v2.1.2] - 2023-09-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ defmt = { version = "0.3" }
 lora-modulation = { version = ">=0.1.2" }
 num-traits = { version = "0.2", default-features = false }
 
-embedded-hal-async = { version = "=1.0.0-rc.1"}
+embedded-hal-async = { version = "=1.0.0-rc.3"}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2023-06-28"
+channel = "beta-2023-12-17"
 components = [ "rust-src", "rustfmt", "clippy" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
-#![feature(async_fn_in_trait)]
 #![allow(incomplete_features)]
+#![allow(async_fn_in_trait)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
@@ -15,7 +15,7 @@ pub mod sx1261_2;
 /// Specific implementation to support Semtech Sx127x chips
 pub mod sx1276_7_8_9;
 
-pub use embedded_hal_async::delay::DelayUs;
+pub use embedded_hal_async::delay::DelayNs;
 use interface::*;
 use mod_params::*;
 use mod_traits::*;
@@ -27,7 +27,7 @@ const MAX_LORA_SYMB_NUM_TIMEOUT: u32 = 248;
 pub struct LoRa<RK, DLY>
 where
     RK: RadioKind,
-    DLY: DelayUs,
+    DLY: DelayNs,
 {
     radio_kind: RK,
     delay: DLY,
@@ -42,7 +42,7 @@ where
 impl<RK, DLY> LoRa<RK, DLY>
 where
     RK: RadioKind,
-    DLY: DelayUs,
+    DLY: DelayNs,
 {
     /// Build and return a new instance of the LoRa physical layer API to control an initialized LoRa radio
     pub async fn new(radio_kind: RK, enable_public_network: bool, delay: DLY) -> Result<Self, RadioError> {
@@ -277,7 +277,10 @@ where
         rx_pkt_params: &PacketParams,
         receiving_buffer: &mut [u8],
     ) -> Result<(u8, PacketStatus), RadioError> {
-        let IrqState::RxDone(len, status) = self.rx_until_state(rx_pkt_params, receiving_buffer, TargetIrqState::Done).await? else {
+        let IrqState::RxDone(len, status) = self
+            .rx_until_state(rx_pkt_params, receiving_buffer, TargetIrqState::Done)
+            .await?
+        else {
             unreachable!();
         };
         Ok((len, status))
@@ -424,7 +427,7 @@ where
 impl<RK, DLY> AsyncRng for LoRa<RK, DLY>
 where
     RK: RngRadio,
-    DLY: DelayUs,
+    DLY: DelayNs,
 {
     async fn get_random_number(&mut self) -> Result<u32, RadioError> {
         self.rx_continuous = false;

--- a/src/mod_traits.rs
+++ b/src/mod_traits.rs
@@ -1,4 +1,4 @@
-use embedded_hal_async::delay::DelayUs;
+use embedded_hal_async::delay::DelayNs;
 
 use crate::mod_params::*;
 
@@ -6,7 +6,7 @@ use crate::mod_params::*;
 /// to allow this crate to control the LoRa chip.
 pub trait InterfaceVariant {
     /// Reset the LoRa chip
-    async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError>;
+    async fn reset(&mut self, delay: &mut impl DelayNs) -> Result<(), RadioError>;
     /// Wait for the LoRa chip to become available for an operation
     async fn wait_on_busy(&mut self) -> Result<(), RadioError>;
     /// Wait for the LoRa chip to indicate an event has occurred
@@ -59,7 +59,7 @@ pub trait RadioKind {
         modulation_params: &ModulationParams,
     ) -> Result<PacketParams, RadioError>;
     /// Reset the loRa chip
-    async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError>;
+    async fn reset(&mut self, delay: &mut impl DelayNs) -> Result<(), RadioError>;
     /// Ensure the LoRa chip is in the appropriate state to allow operation requests
     async fn ensure_ready(&mut self, mode: RadioMode) -> Result<(), RadioError>;
     /// Perform any necessary antenna initialization
@@ -67,7 +67,7 @@ pub trait RadioKind {
     /// Place the LoRa chip in standby mode
     async fn set_standby(&mut self) -> Result<(), RadioError>;
     /// Place the LoRa chip in power-saving mode
-    async fn set_sleep(&mut self, warm_start_if_possible: bool, delay: &mut impl DelayUs) -> Result<(), RadioError>;
+    async fn set_sleep(&mut self, warm_start_if_possible: bool, delay: &mut impl DelayNs) -> Result<(), RadioError>;
     /// Perform operations to set a multi-protocol chip as a LoRa chip
     async fn set_lora_modem(&mut self, enable_public_network: bool) -> Result<(), RadioError>;
     /// Perform operations to set the LoRa chip oscillator
@@ -133,7 +133,7 @@ pub trait RadioKind {
         radio_mode: RadioMode,
         rx_continuous: bool,
         target_rx_state: TargetIrqState,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
         polling_timeout_in_ms: Option<u32>,
         cad_activity_detected: Option<&mut bool>,
     ) -> Result<TargetIrqState, RadioError>;

--- a/src/sx1261_2/mod.rs
+++ b/src/sx1261_2/mod.rs
@@ -1,7 +1,7 @@
 mod radio_kind_params;
 
 use defmt::debug;
-use embedded_hal_async::delay::DelayUs;
+use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::*;
 pub use radio_kind_params::TcxoCtrlVoltage;
 use radio_kind_params::*;
@@ -235,7 +235,7 @@ where
         })
     }
 
-    async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError> {
+    async fn reset(&mut self, delay: &mut impl DelayNs) -> Result<(), RadioError> {
         self.intf.iv.reset(delay).await
     }
 
@@ -266,7 +266,7 @@ where
         self.intf.iv.disable_rf_switch().await
     }
 
-    async fn set_sleep(&mut self, warm_start_if_possible: bool, delay: &mut impl DelayUs) -> Result<(), RadioError> {
+    async fn set_sleep(&mut self, warm_start_if_possible: bool, delay: &mut impl DelayNs) -> Result<(), RadioError> {
         self.intf.iv.disable_rf_switch().await?;
         let sleep_params = SleepParams {
             wakeup_rtc: false,
@@ -836,7 +836,7 @@ where
         radio_mode: RadioMode,
         rx_continuous: bool,
         target_rx_state: TargetIrqState,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
         polling_timeout_in_ms: Option<u32>,
         cad_activity_detected: Option<&mut bool>,
     ) -> Result<TargetIrqState, RadioError> {

--- a/src/sx1276_7_8_9/mod.rs
+++ b/src/sx1276_7_8_9/mod.rs
@@ -1,7 +1,7 @@
 mod radio_kind_params;
 
 use defmt::debug;
-use embedded_hal_async::delay::DelayUs;
+use embedded_hal_async::delay::DelayNs;
 use embedded_hal_async::spi::*;
 use radio_kind_params::*;
 
@@ -242,7 +242,7 @@ where
         })
     }
 
-    async fn reset(&mut self, delay: &mut impl DelayUs) -> Result<(), RadioError> {
+    async fn reset(&mut self, delay: &mut impl DelayNs) -> Result<(), RadioError> {
         self.intf.iv.reset(delay).await?;
         self.set_sleep(false, delay).await?; // ensure sleep mode is entered so that the LoRa mode bit is set
         Ok(())
@@ -263,7 +263,7 @@ where
         self.intf.iv.disable_rf_switch().await
     }
 
-    async fn set_sleep(&mut self, _warm_start_if_possible: bool, _delay: &mut impl DelayUs) -> Result<(), RadioError> {
+    async fn set_sleep(&mut self, _warm_start_if_possible: bool, _delay: &mut impl DelayNs) -> Result<(), RadioError> {
         self.intf.iv.disable_rf_switch().await?;
         self.write_register(Register::RegOpMode, LoRaMode::Sleep.value(), true)
             .await?;
@@ -674,7 +674,7 @@ where
         radio_mode: RadioMode,
         _rx_continuous: bool,
         target_rx_state: TargetIrqState,
-        delay: &mut impl DelayUs,
+        delay: &mut impl DelayNs,
         polling_timeout_in_ms: Option<u32>,
         cad_activity_detected: Option<&mut bool>,
     ) -> Result<TargetIrqState, RadioError> {


### PR DESCRIPTION
Update to embedded-hal-async 1.0.0-rc.3
Switch toolchain to beta-2023-12-17, when 1.75 is realeased we can just drop the toolchain file.